### PR TITLE
Added missing information about building the generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Create a virtual environment:
     pip install -U pip wheel
     pip install -r requirements.txt
 
-Clone repo with PDDL generators:
+Clone repo with PDDL generators, and build the generators:
 
     git clone git@github.com:AI-Planning/pddl-generators.git
-
+    cd pddl-generators
+    ./build_all
+    
 
 ## Usage
 


### PR DESCRIPTION
I got some errors when running the `generate-instances.py` and these were fixed when I ran the build for the `pddl-generators` repo so I added this info to the README file